### PR TITLE
Update package.mk to build 0.1-9669

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/duckstation-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/duckstation-sa/package.mk
@@ -5,7 +5,7 @@ PKG_NAME="duckstation-sa"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SITE="https://github.com/stenzek/duckstation"
-PKG_VERSION="0.1-9384"
+PKG_VERSION="0.1-9669"
 PKG_LONGDESC="Fast PlayStation 1 emulator for x86-64/AArch32/AArch64 "
 PKG_TOOLCHAIN="manual"
 


### PR DESCRIPTION
build 9669 has the disable PBO update that fixes the performance regression in DS since the next branch was pulled